### PR TITLE
Use prefixed properties in .env files

### DIFF
--- a/application/config/Database.php
+++ b/application/config/Database.php
@@ -1,0 +1,35 @@
+<?php namespace App\Config;
+
+/**
+ * Database configuration class.
+ *
+ * The default application-level database configuration. Allows the application
+ * to set a list of available connection configurations and the active/default connection
+ * configuration to be used when no connection configuration is specified.
+ */
+class Database extends \CodeIgniter\Config\Database
+{
+	/**
+	 * The name of the active connection configuration.
+	 *
+	 * This value should match a key in $availableConnections to tell the system
+	 * which connection configuration to use when no connection configuration is
+	 * specified when connecting to the database/loading the database library.
+	 *
+	 * @var string
+	 */
+	public $activeConnection = 'default';
+
+	/**
+	 * The connection configurations available to this application.
+	 *
+	 * An array of connection configuration classes with keys specifying the name
+	 * which will be used to reference the class in the application and configuration
+	 * files.
+	 *
+	 * @var array
+	 */
+	public $availableConnections = [
+		'default' => "\\App\\Config\\Database\\DefaultConnection",
+	];
+}

--- a/application/config/Database/DefaultConnection.php
+++ b/application/config/Database/DefaultConnection.php
@@ -1,0 +1,122 @@
+<?php namespace App\Config\Database;
+
+/**
+ * The default connection configuration for the application.
+ *
+ * This file will contain the settings needed to access your database.
+ *
+ * Mapping values from CI3 database configuration:
+ * $active_group  - not set here, see $activeConnection in the application's Database config
+ * $query_builder - currently not supported
+ * $db            - set by a combination of $availableConnections in the application's
+ *                  Database config and files like this one to set the configuration
+ *                  of the individual connections.
+ *
+ * The following are the keys used in configuring connection groups in CI3's $db
+ * property and their equivalent properties in CI4's Database Connection config:
+ * 'dsn'          - $dsn
+ * 'hostname'     - $hostname
+ * 'username'     - $username
+ * 'password'     - $password
+ * 'dbdriver'     - Instead of setting this value directly, extend the platform-specific
+ *                  Connection Configuration class (to be added here when available):
+ *      'mysqli' - \CodeIgniter\Config\Database\Connection\MySQLi
+ * 'dbprefix'     - currently not supported
+ * 'pconnect'     - $persistentConnectionEnabled
+ * 'db_debug'     - $debugEnabled
+ * 'cache_on'     - $cacheEnabled - may be modified to reference the cache configuration
+ * 'cachedir'     - currently not supported (to be configured elsewhere)
+ * 'char_set'     - $characterSet
+ * 'dbcollat'     - $collation (MySQLi-only)
+ * 'swap_pre'     - currently not supported
+ * 'encrypt'      - (MySQLi-only) instead of an array with the following options, set
+ *                  the associated properties directly:
+ *      'ssl_key'    - $sslKey
+ *      'ssl_cert'   - $sslCert
+ *      'ssl_ca'     - $sslCA
+ *      'ssl_capath' - $sslCAPath
+ *      'ssl_cipher' - $sslCipher
+ *      'ssl_verify' - $sslVerify
+ * 'compress'     - $compressionEnabled (MySQLi-only)
+ * 'stricton'     - $strictSQLEnabled
+ * 'failover'     - $failover Instead of an array containing connection configurations,
+ *                  this will contain values matching keys used in the application's
+ *                  database configuration's $availableConnections property
+ * 'save_queries' - $saveStatementsEnabled
+ * 'port'         - $port
+ *
+ * Additional configuration options:
+ * $deleteHack    - (MySQLi-only)
+ *
+ * The order of the properties below has been arranged (and their values have been
+ * set) to match the default connection group in CI3's database config.
+ */
+class DefaultConnection extends \CodeIgniter\Config\Database\Connection\MySQLi
+{
+	/**
+	 * Data Source Name.
+	 *
+	 * A string which will usually contain all of the settings required to connect
+	 * to a database. Commonly used for database adapters which support multiple
+	 * database types, like PDO or ODBC.
+	 *
+	 * @var string
+	 */
+	public $dsn = '';
+
+	/** @var string The database server's hostname. */
+	public $hostname = 'localhost';
+
+	/** @var string The username for the database connection. */
+	public $username = '';
+
+	/** @var string The password for the database connection. */
+	public $password = '';
+
+	/** @var string The name of the database. */
+	public $database = '';
+
+	/** @var bool Use a persistent connection. */
+	public $persistentConnectionEnabled = false;
+
+	/** @var bool Enable debug messages. */
+	public $debugEnabled = (ENVIRONMENT !== 'production');
+
+	/** @var bool Enable database result caching. */
+	public $cacheEnabled = false;
+
+	/** @var string The character set. */
+	public $characterSet = 'utf8';
+
+	/** @var string The character collation used in communicating with the database. */
+	public $collation = 'utf8_general_ci';
+
+	/** @var bool Whether client compression is enabled. */
+	public $compressionEnabled = false;
+
+	/** @var bool Forces "Strict Mode" connections to enforce strict SQL. */
+	public $strictSQLEnabled = false;
+
+	/**
+	 * List of connections to use if this one fails to connect.
+	 *
+	 * The values in this array should match the keys used in the application's
+	 * Database config to reference other connection configuration classes.
+	 *
+	 * @var array
+	 */
+	public $failover = [];
+
+	/**
+	 * Whether to "save" all executed SQL statements.
+	 *
+	 * Disabling this will also effectively disable application-level profiling
+	 * of SQL statements.
+	 *
+	 * Enabling this setting may cause high memory use, especially when running
+	 * a lot of SQL statements.
+	 *
+	 * @var bool
+	 */
+	public $saveStatementsEnabled = true;
+}

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -20,10 +20,15 @@ class BaseConfig
 	public function __construct()
 	{
 		$properties = array_keys(get_object_vars($this));
+		$prefix = get_class($this);
 
 		foreach ($properties as $property)
 		{
-			if ($value = getenv($property))
+			if ($value = getenv("{$prefix}.{$property}"))
+			{
+				$this->{$property} = $value;
+			}
+			elseif ($value = getenv($property))
 			{
 				$this->{$property} = $value;
 			}

--- a/system/Config/Database.php
+++ b/system/Config/Database.php
@@ -1,0 +1,37 @@
+<?php namespace CodeIgniter\Config;
+
+/**
+ * Database configuration class.
+ *
+ * A base class for application-level database configuration. Allows the application
+ * to set a list of available connection configurations and the active/default connection
+ * configuration to be used when no connection configuration is specified.
+ */
+class Database extends \CodeIgniter\Config\BaseConfig
+{
+	/** @var string The name of the active connection. */
+	public $activeConnection;
+
+	/** @var array Connection names and the classes those names reference. */
+	public $availableConnections = [];
+
+	/**
+	 * Allows a Database configuration to be built from a parameter array at run-time.
+	 *
+	 * @param array $params Property name/value pairs to set in the database config.
+	 */
+	public function __construct($params = [])
+	{
+		parent::__construct();
+
+		// Allow $params to override environment variables.
+		if (isset($params['availableConnections']))
+		{
+			$this->availableConnections = $params['availableConnections'];
+		}
+		if (isset($params['activeConnection']))
+		{
+			$this->activeConnection = $params['activeConnection'];
+		}
+	}
+}

--- a/system/Config/Database/Connection.php
+++ b/system/Config/Database/Connection.php
@@ -1,0 +1,99 @@
+<?php namespace CodeIgniter\Config\Database;
+
+/**
+ * Database Connection configuration class.
+ *
+ * A base class for database connection configuration.
+ *
+ * This class is intended to be a base class for other system-level configuration
+ * classes, not for application-level database connection configuration. Applications
+ * should extend the platform-specific system-level connection configuration class
+ * for their database.
+ */
+abstract class Connection extends \CodeIgniter\Config\BaseConfig
+{
+	/** @var bool Enable database result caching. */
+	public $cacheEnabled = false;
+
+	/** @var string The character set. */
+	public $characterSet = 'utf8';
+
+	/** @var string The name of the database. */
+	public $database = '';
+
+	/** @var bool Enable debug messages. */
+	public $debugEnabled = false;
+
+	/**
+	 * Data Source Name.
+	 *
+	 * A string which will usually contain all of the settings required to connect
+	 * to a database. Commonly used for database adapters which support multiple
+	 * database types, like PDO or ODBC.
+	 *
+	 * @var string
+	 */
+	public $dsn = '';
+
+	/** @var array List of connections to use if this one fails to connect. */
+	public $failover = [];
+
+	/** @var string The database server's hostname. */
+	public $hostname = '';
+
+	/** @var string The password for the database connection. */
+	public $password = '';
+
+	/** @var bool Use a persistent connection. */
+	public $persistentConnectionEnabled = false;
+
+	/**
+	 * The port used to connect to the database server.
+	 *
+	 * This is usually not set when the server is configured to use the default
+	 * port.
+	 *
+	 * @var int
+	 */
+	public $port;
+
+	/**
+	 * Whether to "save" all executed SQL statements.
+	 *
+	 * Disabling this will also effectively disable application-level profiling
+	 * of SQL statements.
+	 *
+	 * Enabling this setting may cause high memory use, especially when running
+	 * a lot of SQL statements.
+	 *
+	 * @var bool
+	 */
+	public $saveStatementsEnabled = false;
+
+	/** @var bool Forces "Strict Mode" connections to enforce strict SQL. */
+	public $strictSQLEnabled = false;
+
+	/** @var string The username for the database connection. */
+	public $username = '';
+
+	/**
+	 * The name of the adapter to be used by this connection.
+	 * In most cases, this will match the name of the Connection class itself.
+	 *
+	 * This is intended to be set by the system-level platform-specific configuration
+	 * class, and should not be modified by the application.
+	 *
+	 * @var string
+	 */
+	protected $adapter;
+
+	/**
+	 * Get the name of the adapter to be used by the connection.
+	 *
+	 * @return string The name of the adapter.
+	 */
+	public function getAdapter()
+	{
+		return $this->adapter;
+	}
+}

--- a/system/Config/Database/Connection/MySQLi.php
+++ b/system/Config/Database/Connection/MySQLi.php
@@ -1,0 +1,64 @@
+<?php namespace CodeIgniter\Config\Database\Connection;
+
+/**
+ * This is the base class to be used when configuring a connection to a MySQL database
+ * using PHP's MySQLi extension. The application's database connection configuration
+ * class should extend this class and configure the appropriate values to connect
+ * to the database.
+ */
+class MySQLi extends \CodeIgniter\Config\Database\Connection
+{
+	/** @var string The character collation used in communicating with the database. */
+	public $collation = 'utf8_general_ci';
+
+	/** @var bool Whether client compression is enabled. */
+	public $compressionEnabled = false;
+
+	/**
+	 * Whether to use the MySQL "delete hack" which allows the number of affected
+	 * rows to be shown.
+	 *
+	 * Uses a preg_replace when enabled, adding a little more processing to all
+	 * queries.
+	 *
+	 * @var bool
+	 */
+	public $deleteHack = true;
+
+	/** @var string Path to the private key file for encryption. */
+	public $sslKey;
+
+	/** @var string Path to the public key certificate file for encryption. */
+	public $sslCert;
+
+	/** @var string Path to the certificate authority file for encryption. */
+	public $sslCA;
+
+	/**
+	 * Path to a directory containing trusted CA certificates in PEM format.
+	 *
+	 * @var string
+	 */
+	public $sslCAPath;
+
+	/**
+	 * List of *allowed* ciphers to be used for encryption, separated by colons
+	 * (':').
+	 *
+	 * @var string
+	 */
+	public $sslCipher;
+
+	/** @var bool Whether to verify the server certificate. */
+	public $sslVerify;
+
+	/**
+	 * The name of the adapter to be used by this connection.
+	 * In most cases, this will match the name of the Connection class itself.
+	 *
+	 * This should not be modified/overridden by the application.
+	 *
+	 * @var string
+	 */
+	protected $adapter = 'MySQLi';
+}


### PR DESCRIPTION
As mentioned in discussion regarding database config files, BaseConfig
should prefer env vars prefixed with the classname (and a dot (.)
separator) over env vars using the property name alone.