### PR TITLE
Revert require_once to require

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -35,7 +35,7 @@
  * @filesource
  */
 
-require_once dirname(__FILE__).'/CustomExceptions.php';
+require dirname(__FILE__).'/CustomExceptions.php';
 
 class Exceptions
 {

--- a/tests/CLI/CLITest.php
+++ b/tests/CLI/CLITest.php
@@ -1,0 +1,10 @@
+<?php namespace CodeIgniter\CLI;
+
+class CLITest extends \CIUnitTestCase
+{
+	public function testNew()
+	{
+		$actual = new CLI();
+		$this->assertInstanceOf(CLI::class, $actual);
+	}
+}

--- a/tests/Debug/ExceptionsTest.php
+++ b/tests/Debug/ExceptionsTest.php
@@ -1,0 +1,10 @@
+<?php namespace CodeIgniter\Debug;
+
+class ExceptionsTest extends \CIUnitTestCase
+{
+	public function testNew()
+	{
+		$actual = new Exceptions();
+		$this->assertInstanceOf(Exceptions::class, $actual);
+	}
+}


### PR DESCRIPTION
I changed `require` to `require_once` only to avoid error when coverage reporting: https://github.com/lonnieezell/CodeIgniter4/commit/7d94ace9cecc446626a904ff72627b8ce93d1425#diff-f8c97b2413a23049f611b5e41ecd7ca1

This PR reverts the change. The error occurs only when production code is not loaded during test execution. This PR adds test case files to load production code.
