### PR TITLE
Autoloader can handle multiple paths for PSR-4 autoloading

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -175,6 +175,7 @@ class Autoloader
 			{
 				$this->prefixes[$namespace] = [$this->prefixes[$namespace]];
 			}
+
 			$this->prefixes[$namespace] = array_merge($this->prefixes[$namespace], [$path]);
 		}
 		else
@@ -251,11 +252,13 @@ class Autoloader
 			{
 				$directories = [$directories];
 			}
+
 			foreach ($directories as $directory)
 			{
 				if (strpos($class, $namespace) === 0) {
 					$filePath = $directory . str_replace('\\', '/', substr($class, strlen($namespace))) . '.php';
 					$filename = $this->requireFile($filePath);
+
 					if ($filename) {
 						return $filename;
 					}

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -169,7 +169,19 @@ class Autoloader
 	 */
 	public function addNamespace($namespace, $path)
 	{
-		$this->prefixes[$namespace] = $path;
+		if (isset($this->prefixes[$namespace]))
+		{
+			if (is_string($this->prefixes[$namespace]))
+			{
+				$this->prefixes[$namespace] = [$this->prefixes[$namespace]];
+			}
+			$this->prefixes[$namespace] = array_merge($this->prefixes[$namespace], [$path]);
+		}
+		else
+		{
+			$this->prefixes[$namespace] = [$path];
+		}
+
 
 		return $this;
 	}
@@ -233,12 +245,21 @@ class Autoloader
 			return false;
 		}
 
-		foreach ($this->prefixes as $namespace => $directory)
+		foreach ($this->prefixes as $namespace => $directories)
 		{
-			if (strpos($class, $namespace) === 0)
+			if (is_string($directories))
 			{
-				$filePath = $directory.str_replace('\\', '/', substr($class, strlen($namespace))).'.php';
-				return $this->requireFile($filePath);
+				$directories = [$directories];
+			}
+			foreach ($directories as $directory)
+			{
+				if (strpos($class, $namespace) === 0) {
+					$filePath = $directory . str_replace('\\', '/', substr($class, strlen($namespace))) . '.php';
+					$filename = $this->requireFile($filePath);
+					if ($filename) {
+						return $filename;
+					}
+				}
 			}
 		}
 

--- a/tests/Autoloader/AutoloaderTest.php
+++ b/tests/Autoloader/AutoloaderTest.php
@@ -120,6 +120,24 @@ class AutoloaderTest extends \CIUnitTestCase
 		$this->assertSame($expected, $actual);
 	}
 
+	public function testAddNamespaceMultiplePathsWorks()
+	{
+		$this->loader->addNamespace('My\App', '/my/app');
+		$this->loader->addNamespace('My\App', '/test/app');
+		$this->loader->setFiles([
+			'/my/app/Class.php',
+			'/test/app/ClassTest.php',
+		]);
+
+		$actual = $this->loader->loadClass('My\App\ClassTest');
+		$expected = '/test/app/ClassTest.php';
+		$this->assertSame($expected, $actual);
+
+		$actual = $this->loader->loadClass('My\App\Class');
+		$expected = '/my/app/Class.php';
+		$this->assertSame($expected, $actual);
+	}
+
 	//--------------------------------------------------------------------
 
 	public function testLoadLegacy()


### PR DESCRIPTION
The current autoloader can have only one path for a namespace.
It is not flexible.
