### PR TITLE
Move mock classes to _support

### DIFF
--- a/tests/_support/Autoloader/MockAutoloader.php
+++ b/tests/_support/Autoloader/MockAutoloader.php
@@ -1,0 +1,24 @@
+<?php namespace CodeIgniter\Autoloader;
+
+class MockAutoloader extends Autoloader
+{
+
+	protected $files = [];
+
+	//--------------------------------------------------------------------
+
+	public function setFiles($files)
+	{
+		$this->files = $files;
+	}
+
+	//--------------------------------------------------------------------
+
+	protected function requireFile($file)
+	{
+		return in_array($file, $this->files) ? $file : false;
+	}
+
+	//--------------------------------------------------------------------
+
+}

--- a/tests/_support/HTTP/MockCURLRequest.php
+++ b/tests/_support/HTTP/MockCURLRequest.php
@@ -1,0 +1,37 @@
+<?php namespace CodeIgniter\HTTP;
+
+/**
+ * Class MockCURLRequest
+ *
+ * Simply allows us to not actually call cURL during the
+ * test runs. Instead, we can set the desired output
+ * and get back the set options.
+ */
+class MockCURLRequest extends CURLRequest
+{
+	public $curl_options;
+
+	protected $output = '';
+
+	//--------------------------------------------------------------------
+
+	public function setOutput($output)
+	{
+		$this->output = $output;
+
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	protected function sendRequest(array $curl_options = []): string
+	{
+		// Save so we can access later.
+		$this->curl_options = $curl_options;
+
+		return $this->output;
+	}
+
+	//--------------------------------------------------------------------
+
+}

--- a/tests/_support/Security/MockSecurity.php
+++ b/tests/_support/Security/MockSecurity.php
@@ -1,0 +1,16 @@
+<?php namespace CodeIgniter\Security;
+
+use CodeIgniter\HTTP\RequestInterface;
+
+class MockSecurity extends Security
+{
+	public function CSRFSetCookie(RequestInterface $request)
+	{
+		$_COOKIE['csrf_cookie_name'] = $this->CSRFHash;
+
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+}

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -1,29 +1,5 @@
 <?php namespace CodeIgniter\Autoloader;
 
-class MockAutoloaderClass extends Autoloader
-{
-
-	protected $files = [];
-
-	//--------------------------------------------------------------------
-
-	public function setFiles($files)
-	{
-		$this->files = $files;
-	}
-
-	//--------------------------------------------------------------------
-
-	protected function requireFile($file)
-	{
-		return in_array($file, $this->files) ? $file : false;
-	}
-
-	//--------------------------------------------------------------------
-
-
-}
-
 use Config\Autoload;
 
 //--------------------------------------------------------------------
@@ -48,7 +24,7 @@ class AutoloaderTest extends \CIUnitTestCase
 			'App\Libraries'   => '/application/somewhere',
 		];
 
-		$this->loader = new MockAutoloaderClass();
+		$this->loader = new MockAutoloader();
 		$this->loader->initialize($config);
 
 		$this->loader->setFiles([

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -2,45 +2,6 @@
 
 use Config\App;
 
-/**
- * Class MockCURLRequest
- *
- * Simply allows us to not actually call cURL during the
- * test runs. Instead, we can set the desired output
- * and get back the set options.
- */
-class MockCURLRequest extends CURLRequest
-{
-	public $curl_options;
-
-	protected $output = '';
-
-	//--------------------------------------------------------------------
-
-	public function setOutput($output)
-	{
-		$this->output = $output;
-
-		return $this;
-	}
-
-	//--------------------------------------------------------------------
-
-	protected function sendRequest(array $curl_options = []): string
-	{
-		// Save so we can access later.
-		$this->curl_options = $curl_options;
-
-		return $this->output;
-	}
-
-	//--------------------------------------------------------------------
-
-}
-
-//--------------------------------------------------------------------
-
-
 class CURLRequestTest extends \CIUnitTestCase
 {
 	protected $request;

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -1,19 +1,5 @@
 <?php namespace CodeIgniter\Security;
 
-class MockSecurity extends Security
-{
-	public function CSRFSetCookie(\CodeIgniter\HTTP\RequestInterface $request)
-	{
-		$_COOKIE['csrf_cookie_name'] = $this->CSRFHash;
-
-		return $this;
-	}
-
-	//--------------------------------------------------------------------
-
-
-}
-
 use Config\MockAppConfig;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Request;


### PR DESCRIPTION
There were still test case files which have mock classes.
I moved all mocks to `_support/`.
