### PR TITLE
Fix layout of cli error exception template

### DIFF
--- a/application/Views/errors/cli/error_exception.php
+++ b/application/Views/errors/cli/error_exception.php
@@ -9,13 +9,13 @@ Line Number: <?php echo $exception->getLine(); ?>
 
 <?php if (defined('SHOW_DEBUG_BACKTRACE') && SHOW_DEBUG_BACKTRACE === TRUE): ?>
 
-	Backtrace:
-	<?php foreach ($exception->getTrace() as $error): ?>
-		<?php if (isset($error['file']) && strpos($error['file'], realpath(BASEPATH)) !== 0): ?>
-			File: <?php echo $error['file'], "\n"; ?>
-			Line: <?php echo $error['line'], "\n"; ?>
-			Function: <?php echo $error['function'], "\n\n"; ?>
-		<?php endif ?>
-	<?php endforeach ?>
+Backtrace:
+<?php	foreach ($exception->getTrace() as $error): ?>
+<?php		if (isset($error['file'])): ?>
+	File: <?php echo $error['file'], "\n"; ?>
+	Line: <?php echo $error['line'], "\n"; ?>
+	Function: <?php echo $error['function'], "\n\n"; ?>
+<?php		endif ?>
+<?php	endforeach ?>
 
 <?php endif ?>


### PR DESCRIPTION
The layout of the current template is broken.
It is not HTML, so white spaces matter.

And I remove `&& strpos($error['file'], realpath(BASEPATH)) !== 0)`, which is excluding CodeIgniter system files from backtrace.
Because I don't know why it is needed. It makes difficult to debug.
