### PR TITLE
Refactor of paths detection

### DIFF
--- a/index.php
+++ b/index.php
@@ -105,7 +105,7 @@ $writable_directory = 'writable';
 chdir(__DIR__);
 
 // Are the system and application paths correct?
-if ( ! is_dir($system_path))
+if ( ! realpath($system_path) OR ! is_dir($system_path))
 {
 	header('HTTP/1.1 503 Service Unavailable.', true, 503);
 	echo 'Your system folder path does not appear to be set correctly. Please open the following file and correct this: '.
@@ -113,7 +113,7 @@ if ( ! is_dir($system_path))
 	exit(3); // EXIT_CONFIG
 }
 
-if ( ! is_dir($application_folder))
+if ( ! realpath($application_folder) OR ! is_dir($application_folder))
 {
 	header('HTTP/1.1 503 Service Unavailable.', true, 503);
 	echo 'Your application folder path does not appear to be set correctly. Please open the following file and correct this: '.

--- a/index.php
+++ b/index.php
@@ -101,27 +101,22 @@ $writable_directory = 'writable';
  * ---------------------------------------------------------------
  */
 
-// Set the current directory correctly for CLI requests
-if (defined('STDIN'))
-{
-	chdir(__DIR__);
-}
+// Ensure the current directory is pointing to the front controller's directory
+chdir(__DIR__);
 
-if (($_temp = realpath($system_path)) !== false)
-{
-	$system_path = $_temp.'/';
-}
-else
-{
-	// Ensure there's a trailing slash
-	$system_path = rtrim($system_path, '/').'/';
-}
-
-// Is the system path correct?
+// Are the system and application paths correct?
 if ( ! is_dir($system_path))
 {
 	header('HTTP/1.1 503 Service Unavailable.', true, 503);
 	echo 'Your system folder path does not appear to be set correctly. Please open the following file and correct this: '.
+	     pathinfo(__FILE__, PATHINFO_BASENAME);
+	exit(3); // EXIT_CONFIG
+}
+
+if ( ! is_dir($application_folder))
+{
+	header('HTTP/1.1 503 Service Unavailable.', true, 503);
+	echo 'Your application folder path does not appear to be set correctly. Please open the following file and correct this: '.
 	     pathinfo(__FILE__, PATHINFO_BASENAME);
 	exit(3); // EXIT_CONFIG
 }
@@ -137,36 +132,16 @@ if ( ! is_dir($system_path))
 define('SELF', pathinfo(__FILE__, PATHINFO_BASENAME));
 
 // Path to the system folder
-define('BASEPATH', realpath(str_replace('\\', '/', $system_path)).DIRECTORY_SEPARATOR);
+define('BASEPATH', realpath($system_path).DIRECTORY_SEPARATOR);
 
 // Path to the front controller (this file)
-define('FCPATH', realpath(__DIR__).DIRECTORY_SEPARATOR);
+define('FCPATH', __DIR__.DIRECTORY_SEPARATOR);
 
 // Path to the writable directory.
-define('WRITEPATH', realpath(str_replace('\\', '/', $writable_directory)).DIRECTORY_SEPARATOR);
+define('WRITEPATH', realpath($writable_directory).DIRECTORY_SEPARATOR);
 
 // The path to the "application" folder
-if (is_dir($application_folder))
-{
-	if (($_temp = realpath($application_folder)) !== false)
-	{
-		$application_folder = $_temp;
-	}
-
-	define('APPPATH', realpath($application_folder).DIRECTORY_SEPARATOR);
-}
-else
-{
-	if ( ! is_dir(BASEPATH.$application_folder.DIRECTORY_SEPARATOR))
-	{
-		header('HTTP/1.1 503 Service Unavailable.', true, 503);
-		echo 'Your application folder path does not appear to be set correctly. Please open the following file and correct this: '.
-		     SELF;
-		exit(3); // EXIT_CONFIG
-	}
-
-	define('APPPATH', realpath(BASEPATH.$application_folder).DIRECTORY_SEPARATOR);
-}
+define('APPPATH', realpath($application_folder).DIRECTORY_SEPARATOR);
 
 /*
  * --------------------------------------------------------------------


### PR DESCRIPTION
Hello everyone, I'm aware you're not accepting contributions from the public, but i want to share my 5 cents, and you're free to reject these changes. Following there is a list of the changes and the motivations for each one:
1) Maybe it's better to ensure the current directory is always the FC path
2) is_dir checks both relative and absolute paths so we only need to check if the $system_path and $application_folder are valid directories and then save the constant using realpath
3) realpath(\__DIR__) is redundant because as far as i know \__DIR__ === realpath(\__DIR__)
4) I'm removing the check of application folder inside the system folder because it's an unnecessary operation, since it could be done setting the $application_folder variable to 'system/application';
5) There's no need to replace the directory separators before apply a realpath because the substitution is provided by realpath itself (maybe is it there for the realpath's caching features?)