### PR TITLE
Fix missing DotEnv loading

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -134,6 +134,9 @@ class CodeIgniter
 		define('CI_VERSION', $this->CIVersion);
 
 		require_once BASEPATH.'Common.php';
+
+		$this->loadDotEnv();
+
 		require_once APPPATH.'Config/Services.php';
 
 		$this->loadFrameworkConstants();


### PR DESCRIPTION
I forgot to call `loadDotEnv()`.
