### PR TITLE
Add namespace CodeIgniter\Test and Reflection Helper

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -1,0 +1,26 @@
+<?php namespace CodeIgniter\Test;
+
+use PHPUnit_Framework_TestCase;
+use CodeIgniter\Log\TestLogger;
+
+class CIUnitTestCase extends PHPUnit_Framework_TestCase
+{
+	use ReflectionHelper;
+
+	/**
+	 * Custom function to hook into CodeIgniter's Logging mechanism
+	 * to check if certain messages were logged during code execution.
+	 *
+	 * @param string $level
+	 * @param null   $expectedMessage
+	 */
+	public function assertLogged(string $level, $expectedMessage = null)
+	{
+		$result = TestLogger::didLog($level, $expectedMessage);
+
+		$this->assertTrue($result);
+	}
+
+	//--------------------------------------------------------------------
+
+}

--- a/system/Test/ReflectionHelper.php
+++ b/system/Test/ReflectionHelper.php
@@ -1,0 +1,64 @@
+<?php namespace CodeIgniter\Test;
+
+use ReflectionMethod;
+use ReflectionObject;
+use ReflectionClass;
+
+trait ReflectionHelper
+{
+	/**
+	 * @param object|string $obj    object or class name
+	 * @param string        $method method name
+	 * @return \Closure
+	 */
+	public static function getPrivateMethodInvoker($obj, $method)
+	{
+		$ref_method = new ReflectionMethod($obj, $method);
+		$ref_method->setAccessible(true);
+		$obj = (gettype($obj) === 'object') ? $obj : null;
+
+		return function () use ($obj, $ref_method) {
+			$args = func_get_args();
+			return $ref_method->invokeArgs($obj, $args);
+		};
+	}
+
+	private static function getAccessibleRefProperty($obj, $property)
+	{
+		if (is_object($obj))
+		{
+			$ref_class = new ReflectionObject($obj);
+		}
+		else
+		{
+			$ref_class = new ReflectionClass($obj);
+		}
+
+		$ref_property = $ref_class->getProperty($property);
+		$ref_property->setAccessible(true);
+
+		return $ref_property;
+	}
+
+	/**
+	 * @param object|string $obj      object or class name
+	 * @param string        $property property name
+	 * @param mixed         $value    value
+	 */
+	public static function setPrivateProperty($obj, $property, $value)
+	{
+		$ref_property = self::getAccessibleRefProperty($obj, $property);
+		$ref_property->setValue($obj, $value);
+	}
+
+	/**
+	 * @param object|string $obj      object or class name
+	 * @param string        $property property name
+	 * @return mixed value
+	 */
+	public static function getPrivateProperty($obj, $property)
+	{
+		$ref_property = self::getAccessibleRefProperty($obj, $property);
+		return $ref_property->getValue($obj);
+	}
+}

--- a/tests/_support/CIUnitTestCase.php
+++ b/tests/_support/CIUnitTestCase.php
@@ -1,24 +1,8 @@
 <?php
 
-use CodeIgniter\Log\TestLogger;
+use CodeIgniter\Test;
 
-class CIUnitTestCase extends PHPUnit_Framework_TestCase
+class CIUnitTestCase extends Test\CIUnitTestCase
 {
-	/**
-	 * Custom function to hook into CodeIgniter's Logging mechanism
-	 * to check if certain messages were logged during code execution.
-	 *
-	 * @param string $level
-	 * @param null   $expectedMessage
-	 */
-	public function assertLogged(string $level, $expectedMessage = null)
-	{
-		$result = TestLogger::didLog($level, $expectedMessage);
-
-		$this->assertTrue($result);
-	}
-
-	//--------------------------------------------------------------------
-
-
+	
 }

--- a/tests/system/Test/ReflectionHelperTest.php
+++ b/tests/system/Test/ReflectionHelperTest.php
@@ -1,0 +1,93 @@
+<?php namespace CodeIgniter\Test;
+
+class ReflectionHelperTest extends \CIUnitTestCase
+{
+	public function testGetPrivatePropertyWithObject()
+	{
+		$obj = new __TestForReflectionHelper();
+		$actual = $this->getPrivateProperty($obj, 'private');
+		$this->assertEquals('secret', $actual);
+	}
+
+	public function testGetPrivatePropertyWithObjectStaticCall()
+	{
+		$obj = new __TestForReflectionHelper();
+		$actual = \CIUnitTestCase::getPrivateProperty($obj, 'private');
+		$this->assertEquals('secret', $actual);
+	}
+
+	public function testGetPrivatePropertyWithStatic()
+	{
+		$actual = $this->getPrivateProperty(
+			__TestForReflectionHelper::class, 'static_private'
+		);
+		$this->assertEquals('xyz', $actual);
+	}
+
+	public function testSetPrivatePropertyWithObject()
+	{
+		$obj = new __TestForReflectionHelper();
+		$this->setPrivateProperty(
+			$obj, 'private', 'open'
+		);
+		$this->assertEquals('open', $obj->getPrivate());
+	}
+
+	public function testSetPrivatePropertyWithStatic()
+	{
+		$this->setPrivateProperty(
+			__TestForReflectionHelper::class, 'static_private', 'abc'
+		);
+		$this->assertEquals(
+			'abc', __TestForReflectionHelper::getStaticPrivate()
+		);
+	}
+
+	public function testGetPrivateMethodInvokerWithObject()
+	{
+		$obj = new __TestForReflectionHelper();
+		$method = $this->getPrivateMethodInvoker(
+			$obj, 'privateMethod'
+		);
+		$this->assertEquals(
+			'private param1param2', $method('param1', 'param2')
+		);
+	}
+
+	public function testGetPrivateMethodInvokerWithStatic()
+	{
+		$method = $this->getPrivateMethodInvoker(
+			__TestForReflectionHelper::class, 'privateStaticMethod'
+		);
+		$this->assertEquals(
+			'private_static param1param2', $method('param1', 'param2')
+		);
+	}
+}
+
+
+class __TestForReflectionHelper
+{
+	private $private = 'secret';
+	private static $static_private = 'xyz';
+
+	public function getPrivate()
+	{
+		return $this->private;
+	}
+
+	public static function getStaticPrivate()
+	{
+		return self::$static_private;
+	}
+
+	private function privateMethod($param1, $param2)
+	{
+		return 'private ' . $param1 . $param2;
+	}
+
+	private static function privateStaticMethod($param1, $param2)
+	{
+		return 'private_static ' . $param1 . $param2;
+	}
+}


### PR DESCRIPTION
1. Move code for testing (like assertions) to `CodeIgniter\Test` namespace. So that we can put test code for it in `tests/system/Test` folder. And this makes `\CIUnitTestCase` has no logic. Users can customize it freely.
2. Add `ReflectionHelper` trait to get/set private or protected properties and access private or protected methods.

I'm not sure the class/method names are good.
Comments are welcome.
