### PR TITLE
Add config for coverage reporting

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,11 +8,17 @@
         stopOnFailure="false"
         stopOnIncomplete="false"
         stopOnSkipped="false">
+
     <testsuites>
         <testsuite name="system">
             <directory>./tests/system</directory>
         </testsuite>
     </testsuites>
+
+    <logging>
+        <log type="coverage-html" target="tests/_support/coverage"/>
+        <log type="coverage-text" target="tests/_support/coverage.txt"/>
+    </logging>
 
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">


### PR DESCRIPTION
If you don't want to generate coverage report, you can use php without Xdebug.
Or

~~~
$ phpunit --no-coverage
~~~
