### PR TITLE
Fix Class 'CodeIgniter\Services' not found

### DIFF
--- a/index.php
+++ b/index.php
@@ -179,6 +179,9 @@ require BASEPATH.'Autoloader/Autoloader.php';
 require APPPATH.'Config/Autoload.php';
 require APPPATH.'Config/Services.php';
 
+// Use Config\Services as CodeIgniter\Services
+class_alias('Config\Services', 'CodeIgniter\Services');
+
 // The Autoloader class only handles namespaces
 // and "legacy" support.
 $loader = CodeIgniter\Services::autoloader();

--- a/system/Services.php
+++ b/system/Services.php
@@ -3,9 +3,7 @@
 /**
  * Class Services
  *
- * This class just uses \Config\Services methods, but you should use this class
- * instead of using \Config\Services directly. If you use it, you could replace
- * the services (objects) with your mocks when testing.
+ * This class is only for IDE auto completion. We don't load this file.
  *
  * @package CodeIgniter
  */


### PR DESCRIPTION
Sorry, I forgot to add loading `CodeIgniter\Services` in `index.php`.
But I found that we don't have to load it.

`class_alias()` works fine for our purpose, and the `system/Services.php` file makes IDE auto complete.
