### PR TITLE
Fix 404 override logic

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -319,6 +319,8 @@ class CodeIgniter
 		$this->benchmark->stop('bootstrap');
 		$this->benchmark->start('routing');
 
+		ob_start();
+
 		$this->controller = $this->router->handle($path);
 		$this->method     = $this->router->methodName();
 
@@ -339,8 +341,6 @@ class CodeIgniter
 	 */
 	protected function startController()
 	{
-		ob_start();
-
 		$this->benchmark->start('controller');
 		$this->benchmark->start('controller_constructor');
 
@@ -407,16 +407,21 @@ class CodeIgniter
 			}
 			else if (is_array($override))
 			{
+				$this->benchmark->start('controller');
+				$this->benchmark->start('controller_constructor');
+
 				$this->controller = $override[0];
 				$this->method     = $override[1];
 
 				unset($override);
+
+				$controller = $this->createController();
+				$this->runController($controller);
 			}
 
-			$controller = $this->createController();
-			$this->runController($controller);
 			$this->gatherOutput();
 			$this->sendResponse();
+
 			return;
 		}
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -103,4 +103,55 @@ class CodeIgniterTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testRun404Override()
+	{
+		$_SERVER['argv'] = [
+			'index.php',
+			'/',
+		];
+		$_SERVER['argc'] = 2;
+
+		// Inject mock router.
+		$routes = Services::routes();
+		$routes->setAutoRoute(false);
+		$routes->set404Override('Home::index');
+		$router = Services::router($routes);
+		Services::injectMock('router', $router);
+
+		ob_start();
+		$this->codeigniter->run();
+		$output = ob_get_clean();
+
+		$this->assertContains('<h1>Welcome to CodeIgniter</h1>', $output);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testRun404OverrideByClosure()
+	{
+		$_SERVER['argv'] = [
+			'index.php',
+			'/',
+		];
+		$_SERVER['argc'] = 2;
+
+		// Inject mock router.
+		$routes = Services::routes();
+		$routes->setAutoRoute(false);
+		$routes->set404Override(function()
+		{
+			echo '404 Override by Closure.';
+		});
+		$router = Services::router($routes);
+		Services::injectMock('router', $router);
+
+		ob_start();
+		$this->codeigniter->run();
+		$output = ob_get_clean();
+
+		$this->assertContains('404 Override by Closure.', $output);
+	}
+
+	//--------------------------------------------------------------------
+
 }


### PR DESCRIPTION
`ob_start()` was too late. Because the router may throw PageNotFoundException.
And in that case, benchmark start `controller` and `controller_constructor` were not called.
