### PR TITLE
Address database driver naming.

### DIFF
--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <phpdoc>
-	<title>CodeIgniter v4.0.0 API</title>
+    <title>CodeIgniter v4.0.0 API</title>
     <parser>
         <target>./api/data/</target>
     </parser>
@@ -21,4 +21,8 @@
             <errors>./api/{DATE}.errors.log</errors>
         </paths>
     </logging>
+    
+    <transformations>
+        <template name="responsive" />
+    </transformations>
 </phpdoc>

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -51,7 +51,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @var    string
 	 */
-	public $DBDriver = 'mysqli';
+	public $DBDriver = 'MySQLi';
 
 	/**
 	 * Sub-driver
@@ -404,7 +404,7 @@ abstract class BaseConnection implements ConnectionInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * The name of the platform in use (mysqli, mssql, etc)
+	 * The name of the platform in use (MySQLi, mssql, etc)
 	 *
 	 * @return mixed
 	 */

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -83,7 +83,7 @@ interface ConnectionInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * The name of the platform in use (mysqli, mssql, etc)
+	 * The name of the platform in use (MySQLi, mssql, etc)
 	 *
 	 * @return mixed
 	 */

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -11,7 +11,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @var    string
 	 */
-	public $DBDriver = 'mysqli';
+	public $DBDriver = 'MySQLi';
 
 	/**
 	 * DELETE hack flag

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -16,7 +16,7 @@ prototype::
 		'username' => 'root',
 		'password' => '',
 		'database' => 'database_name',
-		'DBDriver' => 'mysqli',
+		'DBDriver' => 'MySQLi',
 		'DBPrefix' => '',
 		'pConnect' => TRUE,
 		'DBDebug'  => TRUE,
@@ -62,7 +62,7 @@ These failovers can be specified by setting the failover for a connection like t
 				'username' => '',
 				'password' => '',
 				'database' => '',
-				'DBDriver' => 'mysqli',
+				'DBDriver' => 'MySQLi',
 				'DBPrefix' => '',
 				'pConnect' => TRUE,
 				'DBDebug'  => TRUE,
@@ -80,7 +80,7 @@ These failovers can be specified by setting the failover for a connection like t
 				'username' => '',
 				'password' => '',
 				'database' => '',
-				'DBDriver' => 'mysqli',
+				'DBDriver' => 'MySQLi',
 				'DBPrefix' => '',
 				'pConnect' => TRUE,
 				'DBDebug'  => TRUE,
@@ -109,7 +109,7 @@ example, to set up a "test" environment you would do this::
 		'username' => 'root',
 		'password' => '',
 		'database' => 'database_name',
-		'DBDriver' => 'mysqli',
+		'DBDriver' => 'MySQLi',
 		'DBPrefix' => '',
 		'pConnect' => TRUE,
 		'DBDebug'  => TRUE,
@@ -174,7 +174,7 @@ Explanation of Values:
 **username**		The username used to connect to the database.
 **password**		The password used to connect to the database.
 **database**		The name of the database you want to connect to.
-**DBDiver**		The database type. ie: mysqli, postgre, odbc, etc. Must be specified in lower case.
+**DBDiver**		The database type. eg: MySQLi, Postgre, etc. The case must match the driver name
 **DBPrefix**		An optional table prefix which will added to the table name when running
 			:doc:`Query Builder <query_builder>` queries. This permits multiple CodeIgniter
 			installations to share one database.
@@ -186,7 +186,7 @@ Explanation of Values:
 **charset**	    	The character set used in communicating with the database.
 **DBCollat**		The character collation used in communicating with the database
 
-			.. note:: Only used in the 'mysql' and 'mysqli' drivers.
+			.. note:: Only used in the 'MySQLi' driver.
 
 **swapPre**		A default table prefix that should be swapped with dbprefix. This is useful for distributed
 			applications where you might run manually written queries, and need the prefix to still be
@@ -194,15 +194,15 @@ Explanation of Values:
 **schema**		The database schema, defaults to 'public'. Used by PostgreSQL and ODBC drivers.
 **encrypt**		Whether or not to use an encrypted connection.
 
-			  - 'mysql' (deprecated), 'sqlsrv' and 'pdo/sqlsrv' drivers accept TRUE/FALSE
-			  - 'mysqli' and 'pdo/mysql' drivers accept an array with the following options:
+			  - 'sqlsrv' and 'pdo/sqlsrv' drivers accept TRUE/FALSE
+			  - 'MySQLi' and 'pdo/mysql' drivers accept an array with the following options:
 			  
 			    - 'ssl_key'    - Path to the private key file
 			    - 'ssl_cert'   - Path to the public key certificate file
 			    - 'ssl_ca'     - Path to the certificate authority file
 			    - 'ssl_capath' - Path to a directory containing trusted CA certificats in PEM format
 			    - 'ssl_cipher' - List of *allowed* ciphers to be used for the encryption, separated by colons (':')
-			    - 'ssl_verify' - TRUE/FALSE; Whether to verify the server certificate or not ('mysqli' only)
+			    - 'ssl_verify' - TRUE/FALSE; Whether to verify the server certificate or not ('MySQLi' only)
 
 **compress**		Whether or not to use client compression (MySQL only).
 **strictOn**		TRUE/FALSE (boolean) - Whether to force "Strict Mode" connections, good for ensuring strict SQL

--- a/user_guide_src/source/intro/requirements.rst
+++ b/user_guide_src/source/intro/requirements.rst
@@ -7,11 +7,18 @@ Server Requirements
 A database is required for most web application programming.
 Currently supported databases are:
 
-  - MySQL (5.1+) via the *mysqli* and *pdo* drivers
+  - MySQL (5.1+) via the *MySQLi* driver
+  - PostgreSQL via the *Postgre* driver
+
+Not all of the drivers have been converted/rewritten for CodeIgniter4. 
+The list below shows the outstanding ones.
+
+  - MySQL (5.1+) via the *pdo* driver
   - Oracle via the *oci8* and *pdo* drivers
-  - PostgreSQL via the *postgre* and *pdo* drivers
+  - PostgreSQL via the *pdo* driver
   - MS SQL via the *mssql*, *sqlsrv* (version 2005 and above only) and *pdo* drivers
   - SQLite via the *sqlite* (version 2), *sqlite3* (version 3) and *pdo* drivers
   - CUBRID via the *cubrid* and *pdo* drivers
   - Interbase/Firebird via the *ibase* and *pdo* drivers
   - ODBC via the *odbc* and *pdo* drivers (you should know that ODBC is actually an abstraction layer)
+


### PR DESCRIPTION
Update the default database name, and make it clear that database driver names are now case-sensitive. I also added a note in the requirements user guide page to show which drivers have been reworked for CI4 and which have not.
Signed-off-by:Master Yoda <jim_parry@bcit.ca>