### PR TITLE
Add @group to database live tests

### DIFF
--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -107,24 +107,31 @@ class CIDatabaseTestCase extends CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function __construct()
+	public function loadDependencies()
 	{
-	    parent::__construct();
-		
-		$this->db = \Config\Database::connect($this->DBGroup);
-		$this->db->initialize();
+		if ($this->db === null)
+		{
+			$this->db = \Config\Database::connect($this->DBGroup);
+			$this->db->initialize();
+		}
 
-		// Ensure that we can run migrations
-		$config = new \Config\Migrations();
-		$config->enabled = true;
+		if ($this->migrations === null)
+		{
+			// Ensure that we can run migrations
+			$config = new \Config\Migrations();
+			$config->enabled = true;
 
-		$this->migrations = Services::migrations($config, $this->db);
-		$this->migrations->setSilent(true);
+			$this->migrations = Services::migrations($config, $this->db);
+			$this->migrations->setSilent(true);
+		}
 
-		$this->seeder = \Config\Database::seeder($this->DBGroup);
-		$this->seeder->setSilent(true);
+		if ($this->seeder === null)
+		{
+			$this->seeder = \Config\Database::seeder($this->DBGroup);
+			$this->seeder->setSilent(true);
+		}
 	}
-	
+
 	//--------------------------------------------------------------------
 
 	/**
@@ -135,6 +142,8 @@ class CIDatabaseTestCase extends CIUnitTestCase
 	 */
 	public function setUp()
 	{
+		$this->loadDependencies();
+
 		if ($this->refresh === true)
 		{
 			if (! empty($this->basePath))

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,7 @@ If running under OS X or Linux, you will want to create a symbolic link to make 
 
 A number of the tests that are ran during the test suite are ran against a running database. In order to setup the database used here, edit the details for the `tests` database group in **application/Config/Database.php**. Make sure that you provide a database engine that is currently running, and have already created a table that you can use only for these tests, as it will be wiped and refreshed often while running the test suite.  
 
-If you want to run the tests without running the live database tests, make a copy of **phpunit.dist.xml**, call it **phpunit.xml**, and un-comment the line within the testsuite that excludes the **tests/system/Database/Live** directory. This will make the tests run quite a bit faster.
+If you want to run the tests without running the live database tests, you can exclude @DatabaseLive group. Or make a copy of **phpunit.dist.xml**, call it **phpunit.xml**, and un-comment the line within the testsuite that excludes the **tests/system/Database/Live** directory. This will make the tests run quite a bit faster.
 
 ## Running the tests
 
@@ -31,6 +31,10 @@ You can limit tests to those within a single test directory by specifying the di
 Individual tests can be ran by including the relative path to the test file.
 
 	> ./phpunit tests/system/HTTP/RequestTest
+
+You can run the tests without running the live database tests.
+
+	> ./phpunit --exclude-group DatabaseLive
 
 ## Generating Code Coverage
 

--- a/tests/system/Database/Live/CIDbTestCaseTest.php
+++ b/tests/system/Database/Live/CIDbTestCaseTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class CIDbTestCaseTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/CountTest.php
+++ b/tests/system/Database/Live/CountTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class CountTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -2,6 +2,9 @@
 
 use CodeIgniter\DatabaseException;
 
+/**
+ * @group DatabaseLive
+ */
 class DeleteTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/EmptyTest.php
+++ b/tests/system/Database/Live/EmptyTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class EmptyTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/FromTest.php
+++ b/tests/system/Database/Live/FromTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class FromTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class GetTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class GroupTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/IncrementTest.php
+++ b/tests/system/Database/Live/IncrementTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class IncrementTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class InsertTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/JoinTest.php
+++ b/tests/system/Database/Live/JoinTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class JoinTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class LikeTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/LimitTest.php
+++ b/tests/system/Database/Live/LimitTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class LimitTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -4,6 +4,9 @@ use CodeIgniter\Model;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\UserModel;
 
+/**
+ * @group DatabaseLive
+ */
 class ModelTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/OrderTest.php
+++ b/tests/system/Database/Live/OrderTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class OrderTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -2,6 +2,9 @@
 
 use CodeIgniter\Database\BaseResult;
 
+/**
+ * @group DatabaseLive
+ */
 class SelectTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -2,6 +2,9 @@
 
 use CodeIgniter\DatabaseException;
 
+/**
+ * @group DatabaseLive
+ */
 class UpdateTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/WhereTest.php
+++ b/tests/system/Database/Live/WhereTest.php
@@ -1,5 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
+/**
+ * @group DatabaseLive
+ */
 class WhereTest extends \CIDatabaseTestCase
 {
 	protected $refresh = true;


### PR DESCRIPTION
This PR adds `@group DatabaseLive` to database live tests.
And you can run tests without database connection:
~~~
$ ./phpunit --exclude-group DatabaseLive
~~~

I'm not sure group naming is good or not.
