### PR TITLE
Typo mistake on ComposerScripts

### DIFF
--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -13,7 +13,7 @@ New core classes:
 
     - CodeIgniter (bootstrap)
     - Common (shared functions)
-    - CompoaseScripts (integrate third party tools)
+    - ComposerScripts (integrate third party tools)
     - Controller (base controller)
     - Model (base model)
 


### PR DESCRIPTION
Typo mistake fix in ComposerScripts name